### PR TITLE
Returns code on active model validation error.

### DIFF
--- a/lib/jsonapi/rails/serializable_active_model_errors.rb
+++ b/lib/jsonapi/rails/serializable_active_model_errors.rb
@@ -2,6 +2,10 @@ module JSONAPI
   module Rails
     # @private
     class SerializableActiveModelError < Serializable::Error
+      code do
+        @code
+      end
+
       title do
         "Invalid #{@field}" unless @field.nil?
       end
@@ -26,9 +30,9 @@ module JSONAPI
 
       def as_jsonapi
         @errors.keys.flat_map do |key|
-          @errors.full_messages_for(key).map do |message|
+          @errors.full_messages_for(key).map.with_index do |message, i|
             SerializableActiveModelError.new(field: key, message: message,
-                                             pointer: @reverse_mapping[key])
+              pointer: @reverse_mapping[key], code: @errors.details[key][i][:error])
               .as_jsonapi
           end
         end

--- a/spec/render_jsonapi_errors_spec.rb
+++ b/spec/render_jsonapi_errors_spec.rb
@@ -17,11 +17,13 @@ describe ActionController::Base, '#render', type: :controller do
     {
       'errors' => [
         {
+          'code' => 'blank'
           'detail' => 'Name can\'t be blank',
           'title' => 'Invalid name',
           'source' => { 'pointer' => '/data/attributes/name' }
         },
         {
+          'code' => 'invalid'
           'detail' => 'Email must be a valid email',
           'title' => 'Invalid email',
           'source' => { 'pointer' => '/data/attributes/email' }


### PR DESCRIPTION
Did not manage to launch tests due to this issue:
```ruby
NoMethodError:
  undefined method `halt_callback_chains_on_return_false=' for ActiveSupport:Module
```